### PR TITLE
feat(waku-relay): add waku-relay crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,5 +2,6 @@
 members = [
     "waku-core",
     "waku-message",
+    "waku-relay",
     "waku-store"
 ]

--- a/waku-relay/Cargo.toml
+++ b/waku-relay/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "waku-relay"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+bytes = "1.3.0"
+libp2p = { version = "0.50.0", features = ["full"] }
+prost = "0.11.3"
+strum_macros = "0.24.3"
+thiserror = "1.0.37"
+waku-message = { version = "0.1.0", path = "../waku-message" }

--- a/waku-relay/src/behaviour.rs
+++ b/waku-relay/src/behaviour.rs
@@ -1,0 +1,76 @@
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+use libp2p::gossipsub::{
+    Gossipsub, GossipsubConfigBuilder, GossipsubMessage, GossipsubVersion, IdentTopic,
+    MessageAuthenticity, MessageId, ValidationMode,
+};
+use libp2p::PeerId;
+use libp2p::swarm::NetworkBehaviour;
+use prost::Message;
+
+use waku_message::{PubsubTopic, WakuMessage};
+use waku_message::proto::waku::message::v1::WakuMessage as WakuMessageProto;
+
+use crate::error::{PublishError, SubscriptionError};
+use crate::event::Event;
+use crate::proto::MAX_WAKU_RELAY_MESSAGE_SIZE;
+
+pub const PROTOCOL_ID: &str = "/vac/waku/relay/2.0.0";
+
+#[derive(NetworkBehaviour)]
+#[behaviour(out_event = "Event")]
+pub struct Behaviour {
+    pubsub: Gossipsub,
+}
+
+impl Default for Behaviour {
+    fn default() -> Self {
+        let message_id_fn = |message: &GossipsubMessage| {
+            let mut hasher = DefaultHasher::new();
+            message.data.hash(&mut hasher);
+            MessageId::from(hasher.finish().to_string())
+        };
+
+        let pubsub_config = GossipsubConfigBuilder::default()
+            .protocol_id(PROTOCOL_ID, GossipsubVersion::V1_1)
+            .validation_mode(ValidationMode::Anonymous) // StrictNoSign
+            .message_id_fn(message_id_fn)
+            .max_transmit_size(MAX_WAKU_RELAY_MESSAGE_SIZE)
+            .build()
+            .expect("valid pubsub configuration");
+
+        let pubsub = Gossipsub::new(MessageAuthenticity::Anonymous, pubsub_config)
+            .expect("valid pubsub configuration");
+
+        Self { pubsub }
+    }
+}
+
+impl Behaviour {
+    pub fn subscribe(&mut self, topic: &PubsubTopic) -> Result<bool, SubscriptionError> {
+        let ident_topic = IdentTopic::new(topic.to_string());
+        self.pubsub.subscribe(&ident_topic).map_err(Into::into)
+    }
+
+    pub fn unsubscribe(&mut self, topic: &PubsubTopic) -> Result<bool, PublishError> {
+        let ident_topic = IdentTopic::new(topic.to_string());
+        self.pubsub.unsubscribe(&ident_topic).map_err(Into::into)
+    }
+
+    pub fn publish(
+        &mut self,
+        topic: &PubsubTopic,
+        msg: WakuMessage,
+    ) -> Result<MessageId, PublishError> {
+        let ident_topic = IdentTopic::new(topic.to_string());
+        let message_proto: WakuMessageProto = msg.into();
+        self.pubsub
+            .publish(ident_topic, message_proto.encode_to_vec())
+            .map_err(Into::into)
+    }
+
+    pub fn add_peer(&mut self, peer_id: &PeerId) {
+        self.pubsub.add_explicit_peer(peer_id);
+    }
+}

--- a/waku-relay/src/error.rs
+++ b/waku-relay/src/error.rs
@@ -1,0 +1,58 @@
+//! Error types that can result from Waku relay.
+
+use libp2p::gossipsub::error::PublishError as GossipsubPublishError;
+use libp2p::gossipsub::error::SubscriptionError as GossipsubSubscriptionError;
+
+use crate::error::PublishError::{Duplicate, GossipsubError, InsufficientPeers, MessageTooLarge};
+use crate::error::SubscriptionError::NotAllowed;
+
+/// Error associated with publishing a Waku message.
+#[derive(Debug, thiserror::Error)]
+pub enum PublishError {
+    /// This message has already been published.
+    #[error("duplicate message")]
+    Duplicate,
+    /// There were no peers to send this message to.
+    #[error("insufficient peers")]
+    InsufficientPeers,
+    /// The overall message was too large. This could be due to excessive topics or an excessive
+    /// message size.
+    #[error("message too large")]
+    MessageTooLarge,
+    /// Unknown Waku relay publish error.
+    #[error("unknown gossipsub publish error")]
+    GossipsubError(GossipsubPublishError),
+}
+
+impl From<GossipsubPublishError> for PublishError {
+    fn from(err: GossipsubPublishError) -> Self {
+        match err {
+            GossipsubPublishError::Duplicate => Duplicate,
+            GossipsubPublishError::InsufficientPeers => InsufficientPeers,
+            GossipsubPublishError::MessageTooLarge => MessageTooLarge,
+            _ => GossipsubError(err),
+        }
+    }
+}
+
+/// Error associated with subscribing to a topic.
+#[derive(Debug, thiserror::Error)]
+pub enum SubscriptionError {
+    /// Couldn't publish our subscription.
+    #[error("subscription publication failed")]
+    PublishError(PublishError),
+    /// We are not allowed to subscribe to this topic by the subscription filter.
+    #[error("subscription not allowed")]
+    NotAllowed,
+}
+
+impl From<GossipsubSubscriptionError> for SubscriptionError {
+    fn from(err: GossipsubSubscriptionError) -> Self {
+        match err {
+            GossipsubSubscriptionError::PublishError(e) => {
+                SubscriptionError::PublishError(e.into())
+            }
+            GossipsubSubscriptionError::NotAllowed => NotAllowed,
+        }
+    }
+}

--- a/waku-relay/src/event.rs
+++ b/waku-relay/src/event.rs
@@ -1,0 +1,61 @@
+use libp2p::gossipsub::GossipsubEvent;
+use libp2p::PeerId;
+use prost::Message;
+use strum_macros::Display;
+
+use waku_message::{MAX_WAKU_MESSAGE_SIZE, PubsubTopic, WakuMessage};
+use waku_message::proto::waku::message::v1::WakuMessage as WakuMessageProto;
+
+#[derive(Debug, Display)]
+pub enum Event {
+    InvalidMessage,
+    Subscribed {
+        peer_id: PeerId,
+        pubsub_topic: PubsubTopic,
+    },
+    Unsubscribed {
+        peer_id: PeerId,
+        pubsub_topic: PubsubTopic,
+    },
+    Message {
+        pubsub_topic: PubsubTopic,
+        message: WakuMessage,
+    },
+    WakuRelayNotSupported {
+        peer_id: PeerId,
+    },
+}
+
+impl From<GossipsubEvent> for Event {
+    fn from(event: GossipsubEvent) -> Self {
+        match event {
+            GossipsubEvent::Subscribed { peer_id, topic } => Self::Subscribed {
+                peer_id,
+                pubsub_topic: PubsubTopic::new(topic.into_string()),
+            },
+            GossipsubEvent::Unsubscribed { peer_id, topic } => Self::Unsubscribed {
+                peer_id,
+                pubsub_topic: PubsubTopic::new(topic.into_string()),
+            },
+            GossipsubEvent::Message { message, .. } => {
+                if message.data.len() > MAX_WAKU_MESSAGE_SIZE {
+                    return Self::InvalidMessage;
+                }
+
+                let waku_message = if let Ok(msg) = WakuMessageProto::decode(&message.data[..]) {
+                    msg.into()
+                } else {
+                    return Self::InvalidMessage;
+                };
+
+                Self::Message {
+                    pubsub_topic: PubsubTopic::new(message.topic.to_string()),
+                    message: waku_message,
+                }
+            }
+            GossipsubEvent::GossipsubNotSupported { peer_id } => {
+                Self::WakuRelayNotSupported { peer_id }
+            }
+        }
+    }
+}

--- a/waku-relay/src/lib.rs
+++ b/waku-relay/src/lib.rs
@@ -1,0 +1,7 @@
+pub use behaviour::*;
+pub use event::*;
+
+mod behaviour;
+pub mod error;
+mod event;
+pub mod proto;

--- a/waku-relay/src/proto.rs
+++ b/waku-relay/src/proto.rs
@@ -1,0 +1,3 @@
+use waku_message::MAX_WAKU_MESSAGE_SIZE;
+
+pub const MAX_WAKU_RELAY_MESSAGE_SIZE: usize = 100 + MAX_WAKU_MESSAGE_SIZE;


### PR DESCRIPTION
Add the Waku relay protocol crate.

- [x] Add a wrapper `NetworkBehaviour` around a Gossipsub instance.
- [x] Expose the basic APIs: 
	+ Wrapped APIs: _subscribe to pubsub topic_, _unsubscribe from pubsub topic_, _publish a message_ and _add a Waku relay peer_.
	+ Wrapped errors (see `error` crate).
 	+ Network behaviour events (see `event` crate).