### PR TITLE
feat(waku-enr): add waku-enr crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "waku-core",
+    "waku-enr",
     "waku-message",
     "waku-relay",
     "waku-store"

--- a/waku-enr/Cargo.toml
+++ b/waku-enr/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "waku-enr"
+description = "Waku v2 ENR"
+version = "0.1.0"
+edition = "2021"
+authors = ["Lorenzo Delgado <lnsdev@proton.me>"]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1.0.66"
+bitflags = "1.3.2"
+enr = { version = "0.7.0", features = ["ed25519", "k256"] }
+multiaddr = { version = "0.17.0", default-features = false }
+serde = "1.0.149"
+
+[dev-dependencies]
+base64 = "0.20.0"

--- a/waku-enr/README.md
+++ b/waku-enr/README.md
@@ -1,0 +1,6 @@
+Waku ENR
+--------
+> RFC 31/WAKU2-ENR: https://rfc.vac.dev/spec/31/
+
+Waku v2 ENR collection of functions and extension traits.
+

--- a/waku-enr/src/capabilities.rs
+++ b/waku-enr/src/capabilities.rs
@@ -1,0 +1,12 @@
+use bitflags::bitflags;
+
+bitflags! {
+    /// The ENR `waku2` node capabilities bitfield.
+    #[derive(Default)]
+    pub struct WakuEnrCapabilities: u8 {
+        const RELAY     = 0b00000001;
+        const STORE     = 0b00000010;
+        const FILTER    = 0b00000100;
+        const LIGHTPUSH = 0b00001000;
+    }
+}

--- a/waku-enr/src/enr.rs
+++ b/waku-enr/src/enr.rs
@@ -1,0 +1,62 @@
+use enr::CombinedKey;
+use multiaddr::Multiaddr;
+
+use crate::capabilities::WakuEnrCapabilities;
+use crate::multiaddrs;
+
+pub type Enr = enr::Enr<CombinedKey>;
+pub type EnrBuilder = enr::EnrBuilder<CombinedKey>;
+
+/// The ENR field specifying the node multiaddrs.
+pub const WAKU2_MULTIADDR_ENR_KEY: &str = "multiaddrs";
+/// The ENR field specifying the node Waku v2 capabilities.
+pub const WAKU2_CAPABILITIES_ENR_KEY: &str = "waku2";
+
+/// Extension trait for Waku v2 ENRs
+pub trait Waku2Enr {
+    /// The multiaddrs field associated with the ENR.
+    fn multiaddrs(&self) -> Option<Vec<Multiaddr>>;
+
+    /// The waku node capabilities bitfield associated with the ENR.
+    fn waku2(&self) -> Option<WakuEnrCapabilities>;
+}
+
+impl Waku2Enr for Enr {
+    fn multiaddrs(&self) -> Option<Vec<Multiaddr>> {
+        if let Some(multiaddrs_bytes) = self.get(WAKU2_MULTIADDR_ENR_KEY) {
+            return multiaddrs::decode(multiaddrs_bytes).ok();
+        }
+        None
+    }
+
+    fn waku2(&self) -> Option<WakuEnrCapabilities> {
+        if let Some(bitfield) = self.get(WAKU2_CAPABILITIES_ENR_KEY) {
+            return match bitfield.len() {
+                1 => WakuEnrCapabilities::from_bits(bitfield[0]),
+                _ => None,
+            };
+        }
+        None
+    }
+}
+
+pub trait WakuEnrBuilder {
+    fn multiaddrs(&mut self, multiaddrs: Vec<Multiaddr>) -> &mut Self;
+
+    fn waku2(&mut self, capabilities: WakuEnrCapabilities) -> &mut Self;
+}
+
+impl WakuEnrBuilder for EnrBuilder {
+    /// Adds a Waku `multiaddr` field to the EnrBuilder.
+    fn multiaddrs(&mut self, addrs: Vec<Multiaddr>) -> &mut Self {
+        let multiaddrs = multiaddrs::encode(&addrs);
+        self.add_value(WAKU2_MULTIADDR_ENR_KEY, &multiaddrs);
+        self
+    }
+
+    /// Adds a Waku `waku2` capabilities bitfield to the EnrBuilder.
+    fn waku2(&mut self, cap: WakuEnrCapabilities) -> &mut Self {
+        self.add_value(WAKU2_CAPABILITIES_ENR_KEY, &[cap.bits()]);
+        self
+    }
+}

--- a/waku-enr/src/lib.rs
+++ b/waku-enr/src/lib.rs
@@ -1,0 +1,9 @@
+//! Waku v2 ENR (EIP-778) collection of functions and an extension trait.
+//! RFC 31/WAKU2-ENR: https://rfc.vac.dev/spec/31/
+
+pub use crate::capabilities::*;
+pub use crate::enr::*;
+
+mod capabilities;
+mod enr;
+mod multiaddrs;

--- a/waku-enr/src/multiaddrs.rs
+++ b/waku-enr/src/multiaddrs.rs
@@ -1,0 +1,62 @@
+use anyhow::anyhow;
+use multiaddr::Multiaddr;
+
+pub fn encode(multiaddrs: &[Multiaddr]) -> Vec<u8> {
+    let mut buffer: Vec<u8> = Vec::new();
+    for addr in multiaddrs {
+        let mut addr_bytes = addr.to_vec();
+        let length_prefix: [u8; 2] = u16::to_be_bytes(addr_bytes.len() as u16);
+
+        buffer.extend_from_slice(&length_prefix);
+        buffer.append(&mut addr_bytes);
+    }
+    buffer
+}
+
+pub fn decode(data: &[u8]) -> anyhow::Result<Vec<Multiaddr>> {
+    let mut buffer = Vec::from(data);
+    let mut multiaddrs: Vec<Multiaddr> = Vec::new();
+
+    while buffer.len() > 2 {
+        let length_prefix: [u8; 2] = {
+            let prefix_bytes = buffer.drain(..2).collect::<Vec<u8>>();
+            prefix_bytes.try_into().expect("2 bytes slice")
+        };
+        let length = u16::from_be_bytes(length_prefix) as usize;
+        if length > buffer.len() {
+            return Err(anyhow!("not enough bytes"));
+        }
+
+        let addr_bytes = buffer.drain(..length).collect::<Vec<u8>>();
+        let addr: Multiaddr = addr_bytes.try_into()?;
+        multiaddrs.push(addr);
+    }
+
+    Ok(multiaddrs)
+}
+
+#[cfg(test)]
+mod tests {
+    use multiaddr::Multiaddr;
+
+    use super::{decode, encode};
+
+    #[test]
+    fn test_multiaddrs_codec() {
+        // Given
+        let multiaddrs: Vec<Multiaddr> = vec![
+            "/dns4/example.com/tcp/443/wss".parse().unwrap(),
+            "/dns4/quic.example.com/tcp/443/quic".parse().unwrap(),
+            "/ip4/7.7.7.7/tcp/3003/p2p/QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhx5N/p2p-circuit/p2p/QmUWYRp3mkQUUVeyGVjcM1fC7kbVxmDieGpGsQzopXivyk"
+                .parse()
+                .unwrap(),
+        ];
+
+        // When
+        let encoded = encode(&multiaddrs);
+        let decoded = decode(&encoded);
+
+        // Then
+        assert!(matches!(decoded, Ok(addrs) if addrs == multiaddrs));
+    }
+}

--- a/waku-enr/tests/integration_test.rs
+++ b/waku-enr/tests/integration_test.rs
@@ -1,0 +1,95 @@
+use std::net::{Ipv4Addr, Ipv6Addr};
+
+use enr::{CombinedKey, EnrKey};
+use multiaddr::Multiaddr;
+
+use waku_enr;
+use waku_enr::{Enr, EnrBuilder, Waku2Enr, WakuEnrBuilder, WakuEnrCapabilities};
+
+///! https://rfc.vac.dev/spec/31/#many-connection-types
+#[test]
+fn test_build_waku_enr() {
+    // Given
+    let tcp: u16 = 10101;
+    let udp: u16 = 20202;
+    let tcp6: u16 = 30303;
+    let udp6: u16 = 40404;
+    let ip: Ipv4Addr = "1.2.3.4".parse().unwrap();
+    let ip6: Ipv6Addr = "1234:5600:101:1::142".parse().unwrap();
+    let capabilities: WakuEnrCapabilities = WakuEnrCapabilities::STORE | WakuEnrCapabilities::RELAY;
+    let multiaddrs: Vec<Multiaddr> = vec![
+        "/dns4/example.com/tcp/443/wss".parse().unwrap(),
+        "/dns4/quic.example.com/tcp/443/quic".parse().unwrap(),
+    ];
+
+    // Signing key
+    let key_secp256k1_base64 = "MaZivCR1kZsI2/1MuSw9mhnLQYqETWwjfcWpyiS20uw=";
+    let mut key_secp256k1_bytes = base64::decode(key_secp256k1_base64).unwrap();
+    let key = CombinedKey::secp256k1_from_bytes(&mut key_secp256k1_bytes).unwrap();
+
+    // When
+    let enr = EnrBuilder::new("v4")
+        .tcp4(tcp)
+        .udp4(udp)
+        .tcp6(tcp6)
+        .udp6(udp6)
+        .ip4(ip)
+        .ip6(ip6)
+        .multiaddrs(multiaddrs)
+        .waku2(capabilities)
+        .build(&key);
+
+    // Then
+    assert!(enr.is_ok());
+}
+
+///! https://rfc.vac.dev/spec/31/#many-connection-types
+#[test]
+fn test_decode_waku_enr() {
+    // Given
+    // Expected values
+    let expected_tcp: u16 = 10101;
+    let expected_udp: u16 = 20202;
+    let expected_tcp6: u16 = 30303;
+    let expected_udp6: u16 = 40404;
+    let expected_ip: Ipv4Addr = "1.2.3.4".parse().unwrap();
+    let expected_ip6: Ipv6Addr = "1234:5600:101:1::142".parse().unwrap();
+    let expected_capabilities: WakuEnrCapabilities =
+        WakuEnrCapabilities::STORE | WakuEnrCapabilities::RELAY;
+    let expected_multiaddrs: Vec<Multiaddr> = vec![
+        "/dns4/example.com/tcp/443/wss".parse().unwrap(),
+        "/dns4/quic.example.com/tcp/443/quic".parse().unwrap(),
+    ];
+
+    // Signing key
+    let key_secp256k1_base64 = "MaZivCR1kZsI2/1MuSw9mhnLQYqETWwjfcWpyiS20uw=";
+    let mut key_secp256k1_bytes = base64::decode(key_secp256k1_base64).unwrap();
+    let expected_key = CombinedKey::secp256k1_from_bytes(&mut key_secp256k1_bytes).unwrap();
+
+    // ENR
+    let enr_base64 = "enr:-PC4QPdY95OvXxYSdzPnWTCEY3u0jr0t925ArgGDGJfsDemgMvl-PuXr23r9fJnJGncdx1yPYT7oB6OJoqsiUjSnF7sBgmlkgnY0gmlwhAECAwSDaXA2kBI0VgABAQABAAAAAAAAAUKKbXVsdGlhZGRyc60AEjYLZXhhbXBsZS5jb20GAbveAwAXNhBxdWljLmV4YW1wbGUuY29tBgG7zAOJc2VjcDI1NmsxoQL72vzMVCejPltbXNukOvJc8Mqj-IiawTVxiYY1WCRSX4N0Y3CCJ3WEdGNwNoJ2X4N1ZHCCTuqEdWRwNoKd1IV3YWt1MgM";
+
+    // When
+    let enr: Enr = enr_base64.parse().expect("valid enr string");
+
+    let tcp = enr.tcp4();
+    let udp = enr.udp4();
+    let tcp6 = enr.tcp6();
+    let udp6 = enr.udp6();
+    let ip = enr.ip4();
+    let ip6 = enr.ip6();
+    let capabilities = enr.waku2();
+    let multiaddrs = enr.multiaddrs();
+    let public_key = enr.public_key();
+
+    // Then
+    assert_eq!(public_key, expected_key.public());
+    assert!(matches!(tcp, Some(value) if value == expected_tcp));
+    assert!(matches!(udp, Some(value) if value == expected_udp));
+    assert!(matches!(tcp6, Some(value) if value == expected_tcp6));
+    assert!(matches!(udp6, Some(value) if value == expected_udp6));
+    assert!(matches!(ip, Some(value) if value == expected_ip));
+    assert!(matches!(ip6, Some(value) if value == expected_ip6));
+    assert!(matches!(capabilities, Some(value) if value == expected_capabilities));
+    assert!(matches!(multiaddrs, Some(value) if value == expected_multiaddrs));
+}


### PR DESCRIPTION
Added support for [RFC 31/WAKU2-ENR](https://rfc.vac.dev/spec/31/):

- [x] Added serialization and deserialization for Waku-specific fields (`multiaddrs` and `waku2`).
- [x] Added extension trait for `EnrBuilder`.
- [x] Added extension trait for `Enr`.