### PR TITLE
chore(enr): remove unused dependency

### DIFF
--- a/waku-enr/Cargo.toml
+++ b/waku-enr/Cargo.toml
@@ -12,7 +12,6 @@ anyhow = "1.0.66"
 bitflags = "1.3.2"
 enr = { version = "0.7.0", features = ["ed25519", "k256"] }
 multiaddr = { version = "0.17.0", default-features = false }
-serde = "1.0.149"
 
 [dev-dependencies]
 base64 = "0.20.0"


### PR DESCRIPTION
Remove the `serde` dependency since it is not used.