### PR TITLE
refactor(waku-enr): export the extension traits and re-export the enr crate

### DIFF
--- a/waku-enr/src/enr_ext.rs
+++ b/waku-enr/src/enr_ext.rs
@@ -1,11 +1,8 @@
-use enr::CombinedKey;
+use enr::{Enr, EnrBuilder, EnrKey};
 use multiaddr::Multiaddr;
 
 use crate::capabilities::WakuEnrCapabilities;
 use crate::multiaddrs;
-
-pub type Enr = enr::Enr<CombinedKey>;
-pub type EnrBuilder = enr::EnrBuilder<CombinedKey>;
 
 /// The ENR field specifying the node multiaddrs.
 pub const WAKU2_MULTIADDR_ENR_KEY: &str = "multiaddrs";
@@ -13,7 +10,7 @@ pub const WAKU2_MULTIADDR_ENR_KEY: &str = "multiaddrs";
 pub const WAKU2_CAPABILITIES_ENR_KEY: &str = "waku2";
 
 /// Extension trait for Waku v2 ENRs
-pub trait Waku2Enr {
+pub trait EnrExt {
     /// The multiaddrs field associated with the ENR.
     fn multiaddrs(&self) -> Option<Vec<Multiaddr>>;
 
@@ -21,7 +18,7 @@ pub trait Waku2Enr {
     fn waku2(&self) -> Option<WakuEnrCapabilities>;
 }
 
-impl Waku2Enr for Enr {
+impl<T: EnrKey> EnrExt for Enr<T> {
     fn multiaddrs(&self) -> Option<Vec<Multiaddr>> {
         if let Some(multiaddrs_bytes) = self.get(WAKU2_MULTIADDR_ENR_KEY) {
             return multiaddrs::decode(multiaddrs_bytes).ok();
@@ -40,13 +37,13 @@ impl Waku2Enr for Enr {
     }
 }
 
-pub trait WakuEnrBuilder {
+pub trait EnrBuilderExt {
     fn multiaddrs(&mut self, multiaddrs: Vec<Multiaddr>) -> &mut Self;
 
     fn waku2(&mut self, capabilities: WakuEnrCapabilities) -> &mut Self;
 }
 
-impl WakuEnrBuilder for EnrBuilder {
+impl<T: EnrKey> EnrBuilderExt for EnrBuilder<T> {
     /// Adds a Waku `multiaddr` field to the EnrBuilder.
     fn multiaddrs(&mut self, addrs: Vec<Multiaddr>) -> &mut Self {
         let multiaddrs = multiaddrs::encode(&addrs);

--- a/waku-enr/src/lib.rs
+++ b/waku-enr/src/lib.rs
@@ -2,8 +2,9 @@
 //! RFC 31/WAKU2-ENR: https://rfc.vac.dev/spec/31/
 
 pub use crate::capabilities::*;
-pub use crate::enr::*;
+pub use crate::enr_ext::*;
+pub use enr;
 
 mod capabilities;
-mod enr;
+mod enr_ext;
 mod multiaddrs;

--- a/waku-enr/tests/integration_test.rs
+++ b/waku-enr/tests/integration_test.rs
@@ -1,10 +1,10 @@
 use std::net::{Ipv4Addr, Ipv6Addr};
 
-use enr::{CombinedKey, EnrKey};
 use multiaddr::Multiaddr;
 
 use waku_enr;
-use waku_enr::{Enr, EnrBuilder, Waku2Enr, WakuEnrBuilder, WakuEnrCapabilities};
+use waku_enr::enr::{CombinedKey, Enr, EnrBuilder, EnrKey};
+use waku_enr::{EnrBuilderExt, EnrExt, WakuEnrCapabilities};
 
 ///! https://rfc.vac.dev/spec/31/#many-connection-types
 #[test]
@@ -70,7 +70,7 @@ fn test_decode_waku_enr() {
     let enr_base64 = "enr:-PC4QPdY95OvXxYSdzPnWTCEY3u0jr0t925ArgGDGJfsDemgMvl-PuXr23r9fJnJGncdx1yPYT7oB6OJoqsiUjSnF7sBgmlkgnY0gmlwhAECAwSDaXA2kBI0VgABAQABAAAAAAAAAUKKbXVsdGlhZGRyc60AEjYLZXhhbXBsZS5jb20GAbveAwAXNhBxdWljLmV4YW1wbGUuY29tBgG7zAOJc2VjcDI1NmsxoQL72vzMVCejPltbXNukOvJc8Mqj-IiawTVxiYY1WCRSX4N0Y3CCJ3WEdGNwNoJ2X4N1ZHCCTuqEdWRwNoKd1IV3YWt1MgM";
 
     // When
-    let enr: Enr = enr_base64.parse().expect("valid enr string");
+    let enr: Enr<CombinedKey> = enr_base64.parse().expect("valid enr string");
 
     let tcp = enr.tcp4();
     let udp = enr.udp4();


### PR DESCRIPTION
Drop the `Enr` and `EnrBuilder` type aliases. Export the extension traits and re-export the [enr crate](https://crates.io/crates/enr). 