### PR TITLE
feat(waku-node): add waku-node crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,5 +3,6 @@ members = [
     "waku-core",
     "waku-enr",
     "waku-message",
+    "waku-node",
     "waku-relay",
 ]

--- a/waku-node/Cargo.toml
+++ b/waku-node/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "waku-node"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1.0.68"
+clap = { version = "4.0.30", features = ["derive"] }
+futures = "0.3.25"
+hex = "0.4.3"
+libp2p = { version = "0.50.0", features = ["yamux", "mplex", "tcp", "tokio", "identify", "dns", "ping", "noise", "macros", "secp256k1"] }
+log = "0.4.17"
+pretty_env_logger = "0.4.0"
+strum_macros = "0.24.3"
+thiserror = "1.0.38"
+tokio = { version = "1.23.0", features = ["sync", "rt", "macros"] }

--- a/waku-node/examples/simple.rs
+++ b/waku-node/examples/simple.rs
@@ -1,0 +1,32 @@
+use anyhow::anyhow;
+use log::LevelFilter;
+
+use waku_node::Node;
+use waku_node::NodeConfigBuilder;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    pretty_env_logger::formatted_builder()
+        .filter_level(LevelFilter::Info)
+        .format_timestamp_millis()
+        .init();
+
+    // Init -----
+    let mut key_raw =
+        hex::decode("2a6ecd4041f9903e6d57fd5841bc89ee40606e78e2be4202fa7d32485b41cb8c")?;
+    let config = NodeConfigBuilder::new()
+        .keypair_from_secp256k1(&mut key_raw)?
+        .build();
+
+    let node = Node::new(config.clone())?;
+
+    // Setup -----
+    let addr = format!("/ip4/{}/tcp/{}", &config.tcp_ipaddr, &config.tcp_port);
+    if let Ok(listen_addr) = addr.parse() {
+        node.switch_listen_on(listen_addr).await?;
+    } else {
+        return Err(anyhow!("invalid listen multiaddr format: {addr:?}"));
+    }
+
+    loop {}
+}

--- a/waku-node/src/behaviour.rs
+++ b/waku-node/src/behaviour.rs
@@ -1,0 +1,6 @@
+pub use behaviour::*;
+pub use event::*;
+
+mod behaviour;
+mod event;
+

--- a/waku-node/src/behaviour/behaviour.rs
+++ b/waku-node/src/behaviour/behaviour.rs
@@ -1,0 +1,28 @@
+use libp2p::{identify, ping};
+use libp2p::identity::PublicKey;
+use libp2p::swarm::NetworkBehaviour;
+
+pub struct Config {
+    pub(crate) local_public_key: PublicKey,
+}
+
+#[derive(NetworkBehaviour)]
+#[behaviour(out_event = "crate::behaviour::event::Event")]
+pub struct Behaviour {
+    pub ping: ping::Behaviour,
+    pub identify: identify::Behaviour,
+}
+
+impl Behaviour {
+    pub fn new(config: Config) -> Self {
+        let identify = identify::Behaviour::new(
+            identify::Config::new("/ipfs/id/1.0.0".to_owned(), config.local_public_key)
+                .with_agent_version(format!("rust-waku/{}", env!("CARGO_PKG_VERSION"))),
+        );
+
+        Self {
+            ping: Default::default(),
+            identify,
+        }
+    }
+}

--- a/waku-node/src/behaviour/event.rs
+++ b/waku-node/src/behaviour/event.rs
@@ -1,0 +1,19 @@
+use libp2p::{identify, ping};
+
+#[derive(Debug)]
+pub enum Event {
+    Ping(ping::Event),
+    Identify(identify::Event),
+}
+
+impl From<ping::Event> for Event {
+    fn from(event: ping::Event) -> Self {
+        Event::Ping(event)
+    }
+}
+
+impl From<identify::Event> for Event {
+    fn from(event: identify::Event) -> Self {
+        Event::Identify(event)
+    }
+}

--- a/waku-node/src/config.rs
+++ b/waku-node/src/config.rs
@@ -1,0 +1,6 @@
+pub use builder::*;
+pub use config::*;
+
+mod builder;
+mod config;
+

--- a/waku-node/src/config/builder.rs
+++ b/waku-node/src/config/builder.rs
@@ -1,0 +1,49 @@
+use std::net::IpAddr;
+
+use libp2p::identity::{Keypair, secp256k1};
+
+use crate::config::config::NodeConfig;
+
+#[derive(Debug, Default)]
+pub struct NodeConfigBuilder {
+    config: NodeConfig,
+}
+
+impl NodeConfigBuilder {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    pub fn build(&mut self) -> NodeConfig {
+        self.config.clone()
+    }
+
+    pub fn keypair(&mut self, keypair: Keypair) -> &mut Self {
+        self.config.keypair = keypair;
+        self
+    }
+
+    // TODO: Move to the nwaku's wakunode2 equivalent
+    pub fn keypair_from_secp256k1(&mut self, bytes: &mut [u8]) -> anyhow::Result<&mut Self> {
+        // let keys: anyhow::Result<Keypair> = {
+        //     let mut key_raw = hex::decode(key).map_err();
+        //     let secret = secp256k1::SecretKey::from_bytes(&mut key_raw)?;
+        //     Ok(Keypair::Secp256k1(secp256k1::Keypair::from(secret)))
+        // };
+
+        let keypair = {
+            let mut key_raw = bytes.as_mut();
+            let secret_key = secp256k1::SecretKey::from_bytes(&mut key_raw)?;
+            Keypair::Secp256k1(secp256k1::Keypair::from(secret_key))
+        };
+
+        self.config.keypair = keypair;
+        Ok(self)
+    }
+
+    pub fn tcp(&mut self, address: IpAddr, port: u16) -> &mut Self {
+        self.config.tcp_ipaddr = address;
+        self.config.tcp_port = port;
+        self
+    }
+}

--- a/waku-node/src/config/config.rs
+++ b/waku-node/src/config/config.rs
@@ -1,0 +1,20 @@
+use std::net::IpAddr;
+
+use libp2p::identity::Keypair;
+
+#[derive(Debug, Clone)]
+pub struct NodeConfig {
+    pub keypair: Keypair,
+    pub tcp_ipaddr: IpAddr,
+    pub tcp_port: u16,
+}
+
+impl Default for NodeConfig {
+    fn default() -> Self {
+        Self {
+            keypair: Keypair::generate_secp256k1(),
+            tcp_ipaddr: "0.0.0.0".parse().expect("valid ip address format"),
+            tcp_port: 0,
+        }
+    }
+}

--- a/waku-node/src/event_loop.rs
+++ b/waku-node/src/event_loop.rs
@@ -1,0 +1,8 @@
+pub use command::*;
+pub use event::*;
+pub use event_loop::*;
+
+mod event_loop;
+mod command;
+mod event;
+

--- a/waku-node/src/event_loop/command.rs
+++ b/waku-node/src/event_loop/command.rs
@@ -1,0 +1,25 @@
+use libp2p::Multiaddr;
+use strum_macros::Display;
+use tokio::sync::oneshot;
+
+#[derive(Debug, Display)]
+pub enum Command {
+    SwitchListenOn {
+        address: Multiaddr,
+        sender: oneshot::Sender<anyhow::Result<()>>,
+    },
+    SwitchDial {
+        address: Multiaddr,
+        sender: oneshot::Sender<anyhow::Result<()>>,
+    },
+}
+
+impl Command {
+    pub fn switch_listen_on(address: Multiaddr, sender: oneshot::Sender<anyhow::Result<()>>) -> Self {
+        Command::SwitchListenOn { address, sender }
+    }
+
+    pub fn switch_dial(address: Multiaddr, sender: oneshot::Sender<anyhow::Result<()>>) -> Self {
+        Command::SwitchDial { address, sender }
+    }
+}

--- a/waku-node/src/event_loop/event.rs
+++ b/waku-node/src/event_loop/event.rs
@@ -1,0 +1,4 @@
+use strum_macros::Display;
+
+#[derive(Debug, Display)]
+pub enum Event {}

--- a/waku-node/src/event_loop/event_loop.rs
+++ b/waku-node/src/event_loop/event_loop.rs
@@ -1,0 +1,74 @@
+use futures::StreamExt;
+use libp2p::swarm::SwarmEvent;
+use log::{debug, error, info, trace};
+use tokio::sync::mpsc;
+
+use crate::behaviour;
+use crate::event_loop::command::Command;
+use crate::event_loop::event::Event;
+
+pub struct EventLoop {
+    switch: libp2p::Swarm<behaviour::Behaviour>,
+    command_source: mpsc::Receiver<Command>,
+    event_sink: mpsc::Sender<Event>,
+}
+
+impl EventLoop {
+    pub fn new(
+        switch: libp2p::Swarm<behaviour::Behaviour>,
+        command_source: mpsc::Receiver<Command>,
+        event_sink: mpsc::Sender<Event>,
+    ) -> Self {
+        Self {
+            switch,
+            command_source,
+            event_sink,
+        }
+    }
+
+    pub async fn dispatch(mut self) {
+        loop {
+            tokio::select! {
+                command = self.command_source.recv() => match command {
+                    Some(cmd) => { self.handle_command(cmd).await; },
+                    None => { debug!("got empty command. terminating node event loop"); return },
+                },
+                event = self.switch.select_next_some() => match event {
+                    SwarmEvent::NewListenAddr { address, .. } => info!("switch listening on: {address:?}"),
+                    SwarmEvent::Behaviour(event) => debug!("{event:?}"),
+                    _ => {}
+                },
+            }
+        }
+    }
+
+    async fn handle_command(&mut self, cmd: Command) {
+        match cmd {
+            Command::SwitchListenOn { address, sender } => {
+                trace!("handle command: {}", "switch_listen_on");
+
+                match self.switch.listen_on(address) {
+                    Ok(_) => sender.send(Ok(())),
+                    Err(e) => sender.send(Err(e.into())),
+                }
+                    .unwrap_or_else(|e| {
+                        error!(
+                        "send '{}' command response failed: {:?}.",
+                        "switch_listen_on", e
+                    );
+                    });
+            }
+            Command::SwitchDial { address, sender } => {
+                trace!("handle command: {}", "switch_dial");
+
+                match self.switch.dial(address) {
+                    Ok(_) => sender.send(Ok(())),
+                    Err(e) => sender.send(Err(e.into())),
+                }
+                    .unwrap_or_else(|e| {
+                        error!("send '{}' command response failed: {:?}.", "switch_dial", e);
+                    });
+            }
+        }
+    }
+}

--- a/waku-node/src/lib.rs
+++ b/waku-node/src/lib.rs
@@ -1,0 +1,8 @@
+pub use config::*;
+pub use node::*;
+
+mod behaviour;
+mod config;
+mod event_loop;
+mod node;
+mod transport;

--- a/waku-node/src/node.rs
+++ b/waku-node/src/node.rs
@@ -1,0 +1,66 @@
+use libp2p::{Multiaddr, PeerId};
+use log::debug;
+use tokio::sync::{mpsc, oneshot};
+
+use crate::behaviour::Behaviour;
+use crate::behaviour::Config as BehaviourConfig;
+use crate::config::NodeConfig;
+use crate::event_loop::{Command, Event, EventLoop};
+use crate::transport::create_transport;
+
+pub struct Node {
+    config: NodeConfig,
+    peer_id: PeerId,
+    command_sender: mpsc::Sender<Command>,
+    event_receiver: mpsc::Receiver<Event>,
+}
+
+impl Node {
+    pub fn new(config: NodeConfig) -> anyhow::Result<Self> {
+        let peer_id = PeerId::from(&config.keypair.public());
+
+        let switch = {
+            let transport = create_transport(&config.keypair)?;
+            let behaviour = Behaviour::new(BehaviourConfig {
+                local_public_key: config.keypair.public(),
+            });
+            libp2p::Swarm::with_tokio_executor(transport, behaviour, peer_id)
+        };
+
+        let (command_sender, command_receiver) = mpsc::channel(32);
+        let (event_sender, event_receiver) = mpsc::channel(32);
+        let mut ev_loop = EventLoop::new(switch, command_receiver, event_sender);
+
+        debug!("start node event loop");
+        tokio::spawn(ev_loop.dispatch());
+
+        Ok(Self {
+            config,
+            peer_id,
+            command_sender,
+            event_receiver,
+        })
+    }
+
+    pub fn peer_id(&self) -> PeerId {
+        self.peer_id
+    }
+
+    pub async fn switch_listen_on(&self, address: Multiaddr) -> anyhow::Result<()> {
+        let (resp_tx, resp_rx) = oneshot::channel();
+        self.command_sender
+            .send(Command::switch_listen_on(address, resp_tx))
+            .await?;
+
+        resp_rx.await?
+    }
+
+    pub async fn switch_dial(&self, address: Multiaddr) -> anyhow::Result<()> {
+        let (resp_tx, resp_rx) = oneshot::channel();
+        self.command_sender
+            .send(Command::switch_dial(address, resp_tx))
+            .await?;
+
+        resp_rx.await?
+    }
+}

--- a/waku-node/src/transport.rs
+++ b/waku-node/src/transport.rs
@@ -1,0 +1,32 @@
+use std::time::Duration;
+
+use libp2p::{core, dns, mplex, noise, PeerId, tcp, Transport, yamux};
+use libp2p::identity::Keypair;
+
+// create the libp2p transport for the node
+pub fn create_transport(
+    keypair: &Keypair,
+) -> std::io::Result<core::transport::Boxed<(PeerId, core::muxing::StreamMuxerBox)>> {
+    let noise_keys = noise::Keypair::<noise::X25519Spec>::new()
+        .into_authentic(keypair)
+        .expect("signing libp2p-noise static dh keypair failed");
+    let noise_config = noise::NoiseConfig::xx(noise_keys);
+
+    let transport = {
+        let dns_tcp = dns::TokioDnsConfig::system(tcp::tokio::Transport::new(
+            tcp::Config::default().nodelay(true),
+        ))?;
+
+        dns_tcp
+    };
+
+    Ok(transport
+        .upgrade(core::upgrade::Version::V1)
+        .authenticate(noise_config.into_authenticated())
+        .multiplex(core::upgrade::SelectUpgrade::new(
+            yamux::YamuxConfig::default(),
+            mplex::MplexConfig::default(),
+        ))
+        .timeout(Duration::from_secs(20))
+        .boxed())
+}


### PR DESCRIPTION
The `waku-node` crate exposes a convenient API to interact with the waku `NetworkBehaviour`. 
This reference implementation aims to be at par with the Nim implementation, supporting all the available protocols.