### PR TITLE
feat(waku-message): add custom debug trait implementation to waku message

### DIFF
--- a/waku-message/Cargo.toml
+++ b/waku-message/Cargo.toml
@@ -8,4 +8,5 @@ edition = "2021"
 [dependencies]
 byte-unit = { version = "4.0.18", default-features = false, features = ["std"] }
 bytes = "1.3.0"
+hex = "0.4.3"
 prost = "0.11.5"

--- a/waku-message/src/message/message.rs
+++ b/waku-message/src/message/message.rs
@@ -1,12 +1,30 @@
+use std::fmt::{Debug, Formatter};
+
 use bytes::Bytes;
 
 use crate::content_topic::ContentTopic;
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct WakuMessage {
     pub payload: Bytes,
     pub content_topic: ContentTopic,
     pub version: u32,
     pub timestamp: Option<i64>,
     pub ephemeral: bool,
+}
+
+impl Debug for WakuMessage {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let payload_slice = self.payload.get(0..32).unwrap_or(&self.payload[..]);
+        f.debug_struct("WakuMessage")
+            .field("content_topic", &self.content_topic)
+            .field("version", &self.version)
+            .field("timestamp", &self.timestamp)
+            .field("ephemeral", &self.ephemeral)
+            .field(
+                "payload",
+                &format_args!("Bytes(0x{}…)", hex::encode(payload_slice)),
+            )
+            .finish()
+    }
 }


### PR DESCRIPTION
A custom implementation of the `fmt::Debug` trait for the `WakuMessage` has been added to avoid printing the whole payload, with a size of up to 1MB, when debugging/logging.