### PR TITLE
feat(waku-node): support enabling and disabling the relay protocol

### DIFF
--- a/waku-node/src/event_loop/event_loop.rs
+++ b/waku-node/src/event_loop/event_loop.rs
@@ -1,3 +1,4 @@
+use anyhow::anyhow;
 use futures::StreamExt;
 use libp2p::swarm::SwarmEvent;
 use log::{debug, error, info, trace};
@@ -79,10 +80,24 @@ impl EventLoop {
             } => {
                 trace!("handle command: {}", "relay_subscribe");
 
+                if !self.switch.behaviour().waku_relay.is_enabled() {
+                    sender
+                        .send(Err(anyhow!("relay protocol disabled")))
+                        .unwrap_or_else(|e| {
+                            error!(
+                                "send '{}' command response failed: {:?}.",
+                                "relay_subscribe", e
+                            );
+                        });
+                    return;
+                }
+
                 match self
                     .switch
                     .behaviour_mut()
                     .waku_relay
+                    .as_mut()
+                    .unwrap()
                     .subscribe(&pubsub_topic)
                 {
                     Ok(_) => sender.send(Ok(())),
@@ -101,10 +116,24 @@ impl EventLoop {
             } => {
                 trace!("handle command: {}", "relay_unsubscribe");
 
+                if !self.switch.behaviour().waku_relay.is_enabled() {
+                    sender
+                        .send(Err(anyhow!("relay protocol disabled")))
+                        .unwrap_or_else(|e| {
+                            error!(
+                                "send '{}' command response failed: {:?}.",
+                                "relay_unsubscribe", e
+                            );
+                        });
+                    return;
+                }
+
                 match self
                     .switch
                     .behaviour_mut()
                     .waku_relay
+                    .as_mut()
+                    .unwrap()
                     .unsubscribe(&pubsub_topic)
                 {
                     Ok(_) => sender.send(Ok(())),
@@ -124,10 +153,24 @@ impl EventLoop {
             } => {
                 trace!("handle command: {}", "relay_publish");
 
+                if !self.switch.behaviour().waku_relay.is_enabled() {
+                    sender
+                        .send(Err(anyhow!("relay protocol disabled")))
+                        .unwrap_or_else(|e| {
+                            error!(
+                                "send '{}' command response failed: {:?}.",
+                                "relay_publish", e
+                            );
+                        });
+                    return;
+                }
+
                 match self
                     .switch
                     .behaviour_mut()
                     .waku_relay
+                    .as_mut()
+                    .unwrap()
                     .publish(&pubsub_topic, message)
                 {
                     Ok(_) => sender.send(Ok(())),

--- a/waku-node/src/node.rs
+++ b/waku-node/src/node.rs
@@ -25,6 +25,7 @@ impl Node {
             let transport = create_transport(&config.keypair)?;
             let behaviour = Behaviour::new(BehaviourConfig {
                 local_public_key: config.keypair.public(),
+                relay: config.relay.clone(),
             });
             libp2p::Swarm::with_tokio_executor(transport, behaviour, peer_id)
         };


### PR DESCRIPTION
Add support to disable the Waku relay protocol:

- [x] Waku relay protocol can be disabled through the node configuration. The relay is disabled by default if no configuration is provided.
- [x] If the protocol is disabled, the associated event loop commands will fail.

