### PR TITLE
feat(waku-node): add support to keep connections alive

### DIFF
--- a/waku-node/Cargo.toml
+++ b/waku-node/Cargo.toml
@@ -16,5 +16,6 @@ pretty_env_logger = "0.4.0"
 strum_macros = "0.24.3"
 thiserror = "1.0.38"
 tokio = { version = "1.23.0", features = ["sync", "rt", "macros"] }
+void = "1.0.2"
 waku-message = { version = "0.1.0", path = "../waku-message" }
 waku-relay = { version = "0.1.0", path = "../waku-relay" }

--- a/waku-node/examples/simple.rs
+++ b/waku-node/examples/simple.rs
@@ -28,6 +28,7 @@ async fn main() -> anyhow::Result<()> {
     let config = NodeConfigBuilder::new()
         .keypair_from_secp256k1(&mut key_raw)?
         .static_nodes(nodes)
+        .keepalive(true)
         .with_waku_relay(relay_config)
         .build();
 

--- a/waku-node/src/behaviour/behaviour.rs
+++ b/waku-node/src/behaviour/behaviour.rs
@@ -1,18 +1,21 @@
 use libp2p::{identify, ping};
 use libp2p::identity::PublicKey;
 use libp2p::swarm::behaviour::toggle;
+use libp2p::swarm::keep_alive;
 use libp2p::swarm::NetworkBehaviour;
 
 use crate::WakuRelayConfig;
 
 pub struct Config {
     pub local_public_key: PublicKey,
+    pub keep_alive: Option<bool>,
     pub relay: Option<WakuRelayConfig>,
 }
 
 #[derive(NetworkBehaviour)]
 #[behaviour(out_event = "crate::behaviour::event::Event")]
 pub struct Behaviour {
+    pub keep_alive: toggle::Toggle<keep_alive::Behaviour>,
     pub ping: ping::Behaviour,
     pub identify: identify::Behaviour,
     pub waku_relay: toggle::Toggle<waku_relay::Behaviour>,
@@ -20,6 +23,7 @@ pub struct Behaviour {
 
 impl Behaviour {
     pub fn new(config: Config) -> Self {
+        let keep_alive = toggle::Toggle::from(config.keep_alive.map(|_| Default::default()));
         let identify = identify::Behaviour::new(
             identify::Config::new("/ipfs/id/1.0.0".to_owned(), config.local_public_key)
                 .with_agent_version(format!("rust-waku/{}", env!("CARGO_PKG_VERSION"))),
@@ -27,6 +31,7 @@ impl Behaviour {
         let waku_relay = toggle::Toggle::from(config.relay.map(|_| Default::default()));
 
         Self {
+            keep_alive,
             ping: Default::default(),
             identify,
             waku_relay,

--- a/waku-node/src/behaviour/event.rs
+++ b/waku-node/src/behaviour/event.rs
@@ -7,6 +7,12 @@ pub enum Event {
     WakuRelay(waku_relay::Event),
 }
 
+impl From<void::Void> for Event {
+    fn from(_: void::Void) -> Self {
+        unreachable!()
+    }
+}
+
 impl From<ping::Event> for Event {
     fn from(event: ping::Event) -> Self {
         Event::Ping(event)

--- a/waku-node/src/config/config.rs
+++ b/waku-node/src/config/config.rs
@@ -11,6 +11,7 @@ pub struct NodeConfig {
     pub tcp_ipaddr: IpAddr,
     pub tcp_port: u16,
     pub static_nodes: Vec<Multiaddr>,
+    pub keepalive: bool,
     pub relay: Option<WakuRelayConfig>,
 }
 
@@ -21,6 +22,7 @@ impl Default for NodeConfig {
             tcp_ipaddr: "0.0.0.0".parse().expect("valid ip address format"),
             tcp_port: 0,
             static_nodes: Vec::new(),
+            keepalive: false,
             relay: None,
         }
     }
@@ -71,6 +73,11 @@ impl NodeConfigBuilder {
 
     pub fn static_nodes(&mut self, nodes: Vec<Multiaddr>) -> &mut Self {
         self.config.static_nodes = nodes;
+        self
+    }
+
+    pub fn keepalive(&mut self, enable: bool) -> &mut Self {
+        self.config.keepalive = enable;
         self
     }
 

--- a/waku-node/src/node.rs
+++ b/waku-node/src/node.rs
@@ -25,6 +25,7 @@ impl Node {
             let transport = create_transport(&config.keypair)?;
             let behaviour = Behaviour::new(BehaviourConfig {
                 local_public_key: config.keypair.public(),
+                keep_alive: config.keepalive.then_some(config.keepalive),
                 relay: config.relay.clone(),
             });
             libp2p::Swarm::with_tokio_executor(transport, behaviour, peer_id)


### PR DESCRIPTION
Add support for the "`keep_alive` protocol"