### PR TITLE
ci: fix api rate limit exceeded for arduino/setup-protoc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Buf
         uses: bufbuild/buf-setup-action@v1


### PR DESCRIPTION
Add the GH API toke to fix the rate limit failures in the setup protoc stage in the CI pipeline (see: https://github.com/actions/runner-images/issues/602).