### PR TITLE
ci: fix api rate limit exceeded for bufbuild/buf-setup-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
 
       - name: Install Buf
         uses: bufbuild/buf-setup-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Protoc's Prost plugin
         uses: baptiste0928/cargo-install@v1


### PR DESCRIPTION
Add the GH API toke to fix the rate limit failures in the setup _buf_ stage in the CI pipeline (see: https://github.com/bufbuild/buf-setup-action#github-token).