### PR TITLE
fix(waku-relay): use only libp2p's necessary features

### DIFF
--- a/waku-relay/Cargo.toml
+++ b/waku-relay/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 bytes = "1.3.0"
-libp2p = { version = "0.50.0", features = ["full"] }
+libp2p = { version = "0.50.0", features = ["gossipsub", "macros"] }
 prost = "0.11.5"
 strum_macros = "0.24.3"
 thiserror = "1.0.38"


### PR DESCRIPTION
Use only the necessary libp2p's features in the `waku-relay` crate